### PR TITLE
Update requirements.txt

### DIFF
--- a/apps/whereami/whereami-backend/src/requirements.txt
+++ b/apps/whereami/whereami-backend/src/requirements.txt
@@ -14,3 +14,4 @@ opentelemetry-propagator-gcp
 opentelemetry-exporter-gcp-trace
 opentelemetry-instrumentation-flask
 opentelemetry-instrumentation-requests
+six


### PR DESCRIPTION
explicit requirement for six needed now. deploy was failing before with "ModuleNotFoundError: No module named 'six'"